### PR TITLE
Ensures that the tests cannot be affected by local network advertisements.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.0.2
+
+* Fixes test to ensure that it cannot be affected by other services running on the local network.
+
 # 1.0.1
 
 * Fix 'main' property in package.json

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resin-discoverable-services",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Resin.io local service discovery utilities",
   "main": "build/discoverable.js",
   "homepage": "https://github.com/resin-io-modules/resin-discoverable-services",


### PR DESCRIPTION
Also tidies up a few of the test checks.

Connects to #5.