### PR TITLE
Add ability to publish/find services from loopback devices by specifying them explicitly (as well as non-loopback devices).

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ The method returns an array of services that conform to those registered. Each s
     - `String family`: IP family that the referer used (IPv4 or IPv6).
     - `Number port`: The port on which the referer runs.
 
-#### publishServices(services, [callback(error, services)])
+#### publishServices(services, [options, [callback(error, services)]])
 
 Publishes any valid service to the network. If a call to this method is made then a corresponding call to `unpublishServices()` **must** be made before process exit to ensure any existing network sockets are finalised.
 
@@ -87,6 +87,10 @@ Publishes any valid service to the network. If a call to this method is made the
 * `String name`: The name under which to publish the service, (eg. `Resin SSH`).
 * `Number port`: The port number to advertise the service as running on.
 * `String host`: An optional host name to publish the service as running on. This is useful for proxying.
+
+`options` is an object allowing publishing options to be passed:
+
+* `String mdnsInterface`: An IPv4 or IPv6 address of a current valid interface with which to bind the MDNS service to (if unset, first available interface).
 
 
 #### unpublishServices([callback])

--- a/build/discoverable.js
+++ b/build/discoverable.js
@@ -186,9 +186,8 @@ isLoopbackInterface = function(address) {
     family: family
   })) != null ? ref.internal : void 0) == null)) {
     return null;
-  } else {
-    return validFamily;
   }
+  return validFamily;
 };
 
 
@@ -333,7 +332,6 @@ exports.findServices = Promise.method(function(services, timeout, callback) {
  * @param {String} services.name - A string of the service name to advertise as
  * @param {String} services.host - A specific hostname that will be used as the host (useful for proxying or psuedo-hosting). Defaults to current host name should none be given
  * @param {Number} services.port - The port on which the service will be advertised
- * @param {Object} services - An object detailing options to the publish method
  * @param {Object} options - An options object for passing publishing options:
  * @param {String} options.mdnsInterface - The IPv4 or IPv6 address of a current valid interface with which to bind the MDNS service to (if unset, first available interface).
 

--- a/lib/discoverable.coffee
+++ b/lib/discoverable.coffee
@@ -153,7 +153,10 @@ isLoopbackInterface = (address) ->
 	foundIntf = _.find os.networkInterfaces(), (intfInfo) ->
 		_.find intfInfo, address: address
 
-	if not foundIntf? or  not (validFamily = _.find(foundIntf, family: family)?.internal)? then return null else return validFamily
+	if not foundIntf? or  not (validFamily = _.find(foundIntf, family: family)?.internal)?
+		return null
+
+	validFamily
 
 ###
 # @summary Sets the path which will be examined for service definitions.

--- a/lib/discoverable.coffee
+++ b/lib/discoverable.coffee
@@ -153,10 +153,10 @@ isLoopbackInterface = (address) ->
 	foundIntf = _.find os.networkInterfaces(), (intfInfo) ->
 		_.find intfInfo, address: address
 
-	if not foundIntf? or  not (validFamily = _.find(foundIntf, family: family)?.internal)?
+	if not foundIntf? or not (validFamily = _.find(foundIntf, family: family)?.internal)?
 		return null
 
-	validFamily
+	return validFamily
 
 ###
 # @summary Sets the path which will be examined for service definitions.

--- a/lib/discoverable.coffee
+++ b/lib/discoverable.coffee
@@ -151,7 +151,7 @@ isLoopbackInterface = (address) ->
 
 	# Correctly format any IPv6 addresses so we find them.
 	foundIntf = _.find os.networkInterfaces(), (intfInfo) ->
-		_.find intfInfo, address: address
+		_.find(intfInfo, address: address)
 
 	if not foundIntf? or not (validFamily = _.find(foundIntf, family: family)?.internal)?
 		return null

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "gulp-coffee": "^2.2.0",
     "gulp-mocha": "^3.0.0",
     "gulp-util": "^3.0.1",
+    "ip": "^1.1.4",
     "lodash": "^4.0.0",
     "mkdirp": "^0.5.1",
     "mocha": "^3.0.0",

--- a/tests/discovery.spec.coffee
+++ b/tests/discovery.spec.coffee
@@ -268,7 +268,7 @@ describe 'Discoverable Services:', ->
 				# If it is, this test will fail as it will not be able to bind to port 5354.
 				if process.platform isnt 'darwin'
 					discoverableServices.publishServices [
-						{ identifier: '_first._sub._ssh._tcp', name: 'First SSH' , port: 1234 }
+						{ identifier: '_first._sub._ssh._tcp', name: 'First SSH', port: 1234 }
 					], { mdnsInterface: '127.0.0.1' }
 					.then ->
 						discoverableServices.findServices([ '_first._sub._ssh._tcp' ])


### PR DESCRIPTION
Fix test issue where node wouldn't exist in some tests when an error occurred.

Connects to #12.