### PR TITLE
Alter template to that of a more streamlined development workflow.

### DIFF
--- a/versionist.conf.js
+++ b/versionist.conf.js
@@ -1,5 +1,4 @@
 module.exports = {
-
   // This setup allows the editing and parsing of footer tags to get version and type information,
   // as well as ensuring tags of the type 'v<major>.<minor>.<patch>' are used.
   // It increments in a semver compatible fashion and allows the updating of NPM package info.
@@ -9,13 +8,22 @@ module.exports = {
   incrementVersion: 'semver',
   updateVersion: 'npm',
 
+  // Only include a commit when there is a footer of 'Change-Type'.
+  // Ensures commits which do not up versions are not included.
+  // It does mean that commit messages without a relevant footer will not be included in the CHANGELOG.
+  includeCommitWhen: (commit) => {
+    if (commit.footer['Change-Type']) {
+      return true;
+    }
+    return false;
+  },
+
   // Determine the type from 'Change-Type:' tag.
-  // Should no explicit change type be made, then patch is assumed.
+  // Should no explicit change type be made, then no changes are assumed.
   getIncrementLevelFromCommit: (commit) => {
     if (commitType = commit.footer['Change-Type']) {
       return commit.footer['Change-Type'].trim();
     }
-    return 'patch';
   },
 
   // Determine if an issue number is included from a 'Connects-To' tag.

--- a/versionist.conf.js
+++ b/versionist.conf.js
@@ -12,16 +12,13 @@ module.exports = {
   // Ensures commits which do not up versions are not included.
   // It does mean that commit messages without a relevant footer will not be included in the CHANGELOG.
   includeCommitWhen: (commit) => {
-    if (commit.footer['Change-Type']) {
-      return true;
-    }
-    return false;
+    return !!commit.footer['Change-Type'];
   },
 
   // Determine the type from 'Change-Type:' tag.
   // Should no explicit change type be made, then no changes are assumed.
   getIncrementLevelFromCommit: (commit) => {
-    if (commitType = commit.footer['Change-Type']) {
+    if (commit.footer['Change-Type']) {
       return commit.footer['Change-Type'].trim();
     }
   },


### PR DESCRIPTION
This ensures that only commits with a 'Change-Type' are now considered
for version increments and that all other commits are ignored.

Connects-To: #19
Change-Type: patch