### PR TITLE
Modify gulp coffee build to include autogenerated CoffeeScript headers  in output JS

### DIFF
--- a/gulpfile.coffee
+++ b/gulpfile.coffee
@@ -11,7 +11,7 @@ OPTIONS =
 
 gulp.task 'coffee', ->
 	gulp.src(OPTIONS.files.app)
-		.pipe(coffee(bare: true)).on('error', gutil.log)
+		.pipe(coffee(header: true)).on('error', gutil.log)
 		.pipe(gulp.dest('build/'))
 
 gulp.task 'test', ->


### PR DESCRIPTION
Connects to #25

change-type: patch