### PR TITLE
Fixed `ip` being incorrectly listed as a dev dependency when it's a runtime dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "gulp-coffee": "^2.2.0",
     "gulp-mocha": "^3.0.0",
     "gulp-util": "^3.0.1",
-    "ip": "^1.1.4",
     "lodash": "^4.0.0",
     "mkdirp": "^0.5.1",
     "mocha": "^3.0.0",
@@ -44,6 +43,7 @@
   },
   "dependencies": {
     "bluebird": "^3.0.0",
-    "bonjour": "git+https://github.com/resin-io/bonjour.git"
+    "bonjour": "git+https://github.com/resin-io/bonjour.git",
+    "ip": "^1.1.4"
   }
 }


### PR DESCRIPTION
Fixes https://github.com/resin-os/resin-device-toolbox/issues/54